### PR TITLE
Tweaks to ARC submission

### DIFF
--- a/src/pyHepGrid/src/header.py
+++ b/src/pyHepGrid/src/header.py
@@ -11,7 +11,8 @@ header_mappings = {"jmartinez":"pyHepGrid.headers.juan_header",
                    "qpsv27":"pyHepGrid.headers.duncan_hamilton_header",
                    "jniehues":"pyHepGrid.headers.jan_header",
                    "jwhitehead":"pyHepGrid.headers.james_header",
-                   "mheil":"HEJ.hej_header"
+                   "mheil":"HEJ.hej_header",
+                   "andersen":"HEJ.hej_header"
                    }
 
 if "phyip3" in socket.gethostname(): # Hack to get different headers for batch and grid w/ same username
@@ -37,6 +38,7 @@ runfile = "nnlorun.py"
 runmode = "NNLOJET"
 sandbox_dir = "test_sandbox"
 arc_direct = True
+split_dur_ce = True
 slurm_kill_exe = "{0}/kill_server.py".format(os.path.dirname(os.path.realpath(__file__)))
 
 # Database config

--- a/src/pyHepGrid/src/runArcjob.py
+++ b/src/pyHepGrid/src/runArcjob.py
@@ -75,7 +75,7 @@ class RunArc(Backend):
         # Can only use direct in Durham. Otherwise fails!
         # Speeds up submission (according to Stephen)
         if arc_direct and ".dur.scotgrid.ac.uk" in ce:
-            cmd += " --direct "
+            cmd += " -S org.nordugrid.gridftpjob --direct "
         output = util.getOutputCall(cmd.split())
         jobid = output.split("jobid:")[-1].rstrip().strip()
         return jobid

--- a/src/pyHepGrid/src/runArcjob.py
+++ b/src/pyHepGrid/src/runArcjob.py
@@ -63,11 +63,12 @@ class RunArc(Backend):
         """
         import random
         from pyHepGrid.src.header import arc_direct
+        from pyHepGrid.src.header import split_dur_ce
         if test:
             from pyHepGrid.src.header import ce_test as ce
         else:
             from pyHepGrid.src.header import ce_base as ce
-            if ".dur.scotgrid.ac.uk" in ce: # Randomise ce at submission time to reduce load
+            if split_dur_ce and ".dur.scotgrid.ac.uk" in ce: # Randomise ce at submission time to reduce load
                 ce = random.choice(["ce1.dur.scotgrid.ac.uk","ce2.dur.scotgrid.ac.uk"])
 
         cmd = "arcsub -c {0} {1} -j {2}".format(ce, filename, self.arcbd)


### PR DESCRIPTION
Added -S flag for direct submission (direct selection of protocol to use, which should save time)
Don't arbitrarily swap between ce1 and ce2, use only as directed (ce1 is faster than ce2, ce2 really is the backup ce to use in case of failure of ce1).