### PR TITLE
Rivet hej

### DIFF
--- a/hejrun.py
+++ b/hejrun.py
@@ -147,7 +147,6 @@ def set_environment(lhapdf_dir):
     os.environ["LCG_CATALOG_TYPE"] = "lfc"
     os.environ["LCG_GFAL_INFOSYS"] = "lcgbdii.gridpp.rl.ac.uk:2170"
     os.environ['OMP_STACKSIZE']    = "999999"
-    os.environ['RIVET_ANALYSIS_PATH'] = os.getcwd()+"/Rivet/"
     try:
         import gfal2_util.shell
     except KeyError as e:
@@ -282,12 +281,13 @@ def download_runcard(input_folder, runcard, runname, debug_level):
     return os.system("rm {0}".format(tar))+stat
 
 def download_rivet(rivet_folder, debug_level):
-    tar = "RivetAnalyses.tar.gz"
-    print_flush("downloading "+rivet_folder+tar)
-    stat = copy_from_grid(rivet_folder+tar, "", args)
+    tar = os.path.basename(rivet_folder)
+    print_flush("downloading "+rivet_folder)
+    stat = copy_from_grid(rivet_folder, "", args)
     stat += untar_file(tar, debug_level)
-
-    return os.system("rm {0}".format("RivetAnalyses.tar.gz"))+stat
+    rivet_dir = os.path.basename(os.path.splitext(rivet_folder)[0])
+    os.environ['RIVET_ANALYSIS_PATH'] = os.getcwd()+"/"+rivet_dir
+    return os.system("rm {0}".format(tar))+stat
 
 ### Misc ###
 
@@ -356,8 +356,6 @@ if __name__ == "__main__":
         os.execvp("bash", ["bash", "-c",
             "source " + env + " && exec python " + sys.argv[0] + ' "${@}"',
             "--"] + sys.argv[1:])
-
-    os.environ["RIVET_ANALYSIS_PATH"] = os.environ["PWD"]+"/Rivet/"
 
     start_time = datetime.datetime.now()
     print_flush("Start time: {0}".format(start_time.strftime("%d-%m-%Y %H:%M:%S")))

--- a/hejrun.py
+++ b/hejrun.py
@@ -96,8 +96,8 @@ def parse_arguments():
     parser.add_option("--lhapdf_local", help = "name of LHAPDF folder local to the sandbox", default = "lhapdf")
 
     # # Rivet options
-    parser.add_option("--use_custom_rivet", action = "store_true", default = True)
-    parser.add_option("--rivet_folder", default="Wjets/Rivet/",
+    parser.add_option("--use_custom_rivet", action = "store_true", default = False)
+    parser.add_option("--rivet_folder", default="Wjets/Rivet/Rivet.tgz",
                           help = "Provide the location of RivetAnalyses tarball.")
 
     # Socket options

--- a/hejrun.py
+++ b/hejrun.py
@@ -95,6 +95,11 @@ def parse_arguments():
                       default = "util/lhapdf.tar.gz")
     parser.add_option("--lhapdf_local", help = "name of LHAPDF folder local to the sandbox", default = "lhapdf")
 
+    # # Rivet options
+    parser.add_option("--use_custom_rivet", action = "store_true", default = True)
+    parser.add_option("--rivet_folder", default="Wjets/Rivet/",
+                          help = "Provide the location of RivetAnalyses tarball.")
+
     # Socket options
     parser.add_option("-S", "--Sockets", help = "Activate socketed run", action = "store_true", default = False)
     parser.add_option("-p", "--port", help = "Port to connect the sockets to", default = "8888")
@@ -270,15 +275,19 @@ def download_runcard(input_folder, runcard, runname, debug_level):
     tar = warmup_name(runcard,runname)
     print_flush("downloading "+input_folder+"/"+tar)
     stat = copy_from_grid(input_folder+"/"+tar, tar, args)
-    stat += copy_from_grid("Wjets/Rivet/RivetAnalyses.tar.gz", "", args)
     stat += untar_file(tar, debug_level)
 
-    os.system("tar -xzf RivetAnalyses.tar.gz")
-
     # TODO download:
-    #   Generalise rivet analysis Download
     #   Scale setters
     return os.system("rm {0}".format(tar))+stat
+
+def download_rivet(rivet_folder, debug_level):
+    tar = "RivetAnalyses.tar.gz"
+    print_flush("downloading "+rivet_folder+tar)
+    stat = copy_from_grid(rivet_folder+tar, "", args)
+    stat += untar_file(tar, debug_level)
+
+    return os.system("rm {0}".format("RivetAnalyses.tar.gz"))+stat
 
 ### Misc ###
 
@@ -382,6 +391,9 @@ if __name__ == "__main__":
         os.system("ldd {0}".format(args.executable))
 
     status += download_runcard(args.input_folder, args.runcard, args.runname, debug_level)
+
+    if args.use_custom_rivet:
+        status += download_rivet(args.rivet_folder, debug_level)
 
     if status != 0:
         print_flush("download failed")

--- a/hejrun.py
+++ b/hejrun.py
@@ -142,6 +142,7 @@ def set_environment(lhapdf_dir):
     os.environ["LCG_CATALOG_TYPE"] = "lfc"
     os.environ["LCG_GFAL_INFOSYS"] = "lcgbdii.gridpp.rl.ac.uk:2170"
     os.environ['OMP_STACKSIZE']    = "999999"
+    os.environ['RIVET_ANALYSIS_PATH'] = os.getcwd()+"/Rivet/"
     try:
         import gfal2_util.shell
     except KeyError as e:
@@ -269,9 +270,13 @@ def download_runcard(input_folder, runcard, runname, debug_level):
     tar = warmup_name(runcard,runname)
     print_flush("downloading "+input_folder+"/"+tar)
     stat = copy_from_grid(input_folder+"/"+tar, tar, args)
+    stat += copy_from_grid("Wjets/Rivet/RivetAnalyses.tar.gz", "", args)
     stat += untar_file(tar, debug_level)
+
+    os.system("tar -xzf RivetAnalyses.tar.gz")
+
     # TODO download:
-    #   rivet analysis
+    #   Generalise rivet analysis Download
     #   Scale setters
     return os.system("rm {0}".format(tar))+stat
 
@@ -342,6 +347,8 @@ if __name__ == "__main__":
         os.execvp("bash", ["bash", "-c",
             "source " + env + " && exec python " + sys.argv[0] + ' "${@}"',
             "--"] + sys.argv[1:])
+
+    os.environ["RIVET_ANALYSIS_PATH"] = os.environ["PWD"]+"/Rivet/"
 
     start_time = datetime.datetime.now()
     print_flush("Start time: {0}".format(start_time.strftime("%d-%m-%Y %H:%M:%S")))

--- a/nnlorun.py
+++ b/nnlorun.py
@@ -180,6 +180,11 @@ def parse_arguments():
     parser.add_option("--cvmfs_lhapdf_location", default="",
                       help = "Provide a cvmfs location for LHAPDF.")
 
+    # Rivet options (not used)
+    parser.add_option("--use_custom_rivet", action = "store_true", default = False)
+    parser.add_option("--rivet_folder", default="Dummy",
+                          help = "Provide the location of RivetAnalyses tarball.")
+
     # Socket options
     parser.add_option("-S", "--Sockets", help = "Activate socketed run", action = "store_true", default = False)
     parser.add_option("-p", "--port", help = "Port to connect the sockets to", default = "8888")

--- a/sherparun.py
+++ b/sherparun.py
@@ -93,8 +93,8 @@ def parse_arguments():
     parser.add_option("--lhapdf_local", help = "name of LHAPDF folder local to the sandbox", default = "lhapdf")
 
     # # Rivet options
-    parser.add_option("--use_custom_rivet", action = "store_true", default = True)
-    parser.add_option("--rivet_folder", default="Wjets/Rivet/",
+    parser.add_option("--use_custom_rivet", action = "store_true", default = False)
+    parser.add_option("--rivet_folder", default="Wjets/Rivet/Rivet.tgz",
                           help = "Provide the location of RivetAnalyses tarball.")
 
     # Socket options

--- a/sherparun.py
+++ b/sherparun.py
@@ -144,7 +144,6 @@ def set_environment(lhapdf_dir):
     os.environ["LCG_CATALOG_TYPE"] = "lfc"
     os.environ["LCG_GFAL_INFOSYS"] = "lcgbdii.gridpp.rl.ac.uk:2170"
     os.environ['OMP_STACKSIZE']    = "999999"
-    os.environ['RIVET_ANALYSIS_PATH'] = os.getcwd()+"/Rivet/"
     try:
         import gfal2_util.shell
     except KeyError as e:
@@ -275,12 +274,13 @@ def download_runcard(input_folder, runcard, runname, debug_level):
     return os.system("rm {0}".format(tar))+stat
 
 def download_rivet(rivet_folder, debug_level):
-    tar = "RivetAnalyses.tar.gz"
-    print_flush("downloading "+rivet_folder+tar)
-    stat = copy_from_grid(rivet_folder+tar, "", args)
+    tar = os.path.basename(rivet_folder)
+    print_flush("downloading "+rivet_folder)
+    stat = copy_from_grid(rivet_folder, "", args)
     stat += untar_file(tar, debug_level)
-
-    return os.system("rm {0}".format("RivetAnalyses.tar.gz"))+stat
+    rivet_dir = os.path.basename(os.path.splitext(rivet_folder)[0])
+    os.environ['RIVET_ANALYSIS_PATH'] = os.getcwd()+"/"+rivet_dir
+    return os.system("rm {0}".format(tar))+stat
 
 ### Misc ###
 
@@ -325,8 +325,6 @@ if __name__ == "__main__":
         os.execvp("bash", ["bash", "-c",
             "source " + env + " && exec python " + sys.argv[0] + ' "${@}"',
             "--"] + sys.argv[1:])
-
-    os.environ["RIVET_ANALYSIS_PATH"] = os.environ["PWD"]+"/Rivet/"
 
     start_time = datetime.datetime.now()
     print_flush("Start time: {0}".format(start_time.strftime("%d-%m-%Y %H:%M:%S")))

--- a/src/HEJ/hej_header.py
+++ b/src/HEJ/hej_header.py
@@ -65,7 +65,7 @@ lhapdf             = lhapdf_grid_loc
 
 ## Rivet config
 # TODO parse "use_custom_rivet" from config.yml
-use_custom_rivet = True
+use_custom_rivet = False
 grid_rivet_dir = "Wjets/Rivet/Rivet.tgz"
 
 ## Database name (database should be stored on a non-network disk)

--- a/src/HEJ/hej_header.py
+++ b/src/HEJ/hej_header.py
@@ -66,7 +66,7 @@ lhapdf             = lhapdf_grid_loc
 ## Rivet config
 # TODO parse "use_custom_rivet" from config.yml
 use_custom_rivet = True
-grid_rivet_dir = "Wjets/Rivet/"
+grid_rivet_dir = "Wjets/Rivet/Rivet.tgz"
 
 ## Database name (database should be stored on a non-network disk)
 dbname     = scratch_dir("hej_database")

--- a/src/HEJ/hej_header.py
+++ b/src/HEJ/hej_header.py
@@ -63,6 +63,11 @@ lhapdf_ignore_dirs = [] # Don't tar up all of LHAPDF if you don't want to
 lhapdf_central_scale_only = True # Only tar up central [0000.dat] PDF sets
 lhapdf             = lhapdf_grid_loc
 
+## Rivet config
+# TODO parse "use_custom_rivet" from config.yml
+use_custom_rivet = True
+grid_rivet_dir = "Wjets/Rivet/"
+
 ## Database name (database should be stored on a non-network disk)
 dbname     = scratch_dir("hej_database")
 

--- a/src/pyHepGrid/headers/template_header.py
+++ b/src/pyHepGrid/headers/template_header.py
@@ -44,6 +44,10 @@ lhapdf             = "/path/to/lhapdf"
 use_cvmfs_lhapdf = False
 cvmfs_lhapdf_location = "/cvmfs/pheno.egi.eu/lhapdf/6.1.6"
 
+## Rivet config
+use_custom_rivet = False
+grid_rivet_dir = "dummy"
+
 # SQLite Database Parameters
 dbname     = "/path/to/sqlite/database/for/storage.dat"
 provided_warmup_dir = None

--- a/src/pyHepGrid/headers/template_header.py
+++ b/src/pyHepGrid/headers/template_header.py
@@ -46,7 +46,7 @@ cvmfs_lhapdf_location = "/cvmfs/pheno.egi.eu/lhapdf/6.1.6"
 
 ## Rivet config
 use_custom_rivet = False
-grid_rivet_dir = "dummy"
+grid_rivet_dir = None
 
 # SQLite Database Parameters
 dbname     = "/path/to/sqlite/database/for/storage.dat"

--- a/src/pyHepGrid/src/Backend.py
+++ b/src/pyHepGrid/src/Backend.py
@@ -610,6 +610,10 @@ class Backend(_mode):
             dictionary.update({
             "use_cvmfs_lhapdf":header.use_cvmfs_lhapdf,
             "cvmfs_lhapdf_location":header.cvmfs_lhapdf_location})
+        if header.use_custom_rivet:
+            dictionary.update({
+                "use_custom_rivet":header.use_custom_rivet,
+                "rivet_folder":header.grid_rivet_dir})
         return dictionary
 
     def _make_base_argstring(self, runcard, runtag):


### PR DESCRIPTION
Allow for the download and utilization of custom rivet analyses from a location specified in the `hej_header`/`hej_runcard`/`sherpa_runcard` and also an option to not use this new feature. 

Does this break `NNLOJet`? (See addition to `src/pyHepGrid/src/Backend.py`)