### PR TITLE
Copy protocols + Wait time

### DIFF
--- a/hejrun.py
+++ b/hejrun.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import os, sys, datetime
+from random import randint
 try:
     dirac = os.environ["DIRAC"]
     sys.path.append("{0}/Linux_x86_64_glibc-2.12/lib/python2.6/site-packages".format(dirac))
@@ -238,7 +239,7 @@ def gfal_copy(infile, outfile, args, maxrange=MAX_COPY_TRIES):
             # if copying to the grid and it has failed, remove before trying again
             if retval != 0 and "file" not in outfile and not args.Sockets:
                 os.system("gfal-rm {0}".format(outfile_tmp))
-                os.system("sleep 0.5s")
+                os.system("sleep {0}s").format(randint(3,60))
     return 9999999
 
 #### TAR ####

--- a/hejrun.py
+++ b/hejrun.py
@@ -7,7 +7,7 @@ except KeyError as e:
     pass
 
 MAX_COPY_TRIES = 15
-PROTOCOLS = ["xroot", "gsiftp", "srm", "root", "xrootd"]
+PROTOCOLS = ["gsiftp", "xroot", "srm"]
 LHE_FILE="SherpaLHE_fixed.lhe"
 LOG_FILE="output.log"
 

--- a/nnlorun.py
+++ b/nnlorun.py
@@ -11,7 +11,7 @@ from getpass import getuser
 
 RUN_CMD = "OMP_NUM_THREADS={0} ./{1} -run {2}"
 MAX_COPY_TRIES = 15
-PROTOCOLS = ["xroot", "gsiftp", "srm", "root", "xrootd"]
+PROTOCOLS = ["gsiftp", "xroot", "srm"]
 
 ####### MISC ABUSIVE SETUP #######
 #### Override print with custom version that always flushes to stdout so we have up-to-date logs

--- a/nnlorun.py
+++ b/nnlorun.py
@@ -5,6 +5,7 @@ import datetime
 import socket
 from optparse import OptionParser
 from getpass import getuser
+from random import randint
 
 # NOTE: Try to keep this all python2.4 compatible. It may fail at some nodes otherwise :(
 # Hopefully after the shutdown we can rely on python 2.6/7 but that is TBC
@@ -360,6 +361,7 @@ def grid_copy(infile, outfile, args, maxrange=MAX_COPY_TRIES):
             # if copying to the grid and it has failed, remove before trying again
             if retval != 0 and "file" not in outfile and not args.Sockets:
                 os.system("gfal-rm {0}".format(outfile_tmp))
+                os.system("sleep {0}s").format(randint(3,60))
     return 9999999
 ####### END COPY UTILITIES #######
 

--- a/sherparun.py
+++ b/sherparun.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import os, sys, datetime
+from random import randint
 try:
     dirac = os.environ["DIRAC"]
     sys.path.append("{0}/Linux_x86_64_glibc-2.12/lib/python2.6/site-packages".format(dirac))
@@ -231,7 +232,7 @@ def gfal_copy(infile, outfile, args, maxrange=MAX_COPY_TRIES):
             # if copying to the grid and it has failed, remove before trying again
             if retval != 0 and "file" not in outfile and not args.Sockets:
                 os.system("gfal-rm {0}".format(outfile_tmp))
-                os.system("sleep 0.5s")
+                os.system("sleep {0}s").format(randint(3,60))
     return 9999999
 
 #### TAR ####

--- a/sherparun.py
+++ b/sherparun.py
@@ -7,7 +7,7 @@ except KeyError as e:
     pass
 
 MAX_COPY_TRIES = 15
-PROTOCOLS = ["xroot", "gsiftp", "srm", "root", "xrootd"]
+PROTOCOLS = ["gsiftp", "xroot", "srm"]
 LOG_FILE="output.log"
 
 #### Override print with custom version that always flushes to stdout so we have up-to-date logs

--- a/src/pyHepGrid/src/utilities.py
+++ b/src/pyHepGrid/src/utilities.py
@@ -10,6 +10,7 @@ import subprocess
 from sys import version_info
 import tarfile
 from uuid import uuid4
+from random import randint
 #
 # Misc. Utilities
 #
@@ -344,7 +345,7 @@ def gfal_copy(infile, outfile, maxrange=MAX_COPY_TRIES):
             if retval != 0 and "file:" not in outfile:
                 os.system("gfal-rm {0}".format(outfile_tmp))
             # give the server a bit of time
-            sleep(1)
+            os.system("sleep {0}s").format(randint(3,60))
     header.logger.error("Copy failed.")
     return 9999999
 

--- a/src/pyHepGrid/src/utilities.py
+++ b/src/pyHepGrid/src/utilities.py
@@ -16,7 +16,7 @@ from uuid import uuid4
 #
 
 MAX_COPY_TRIES = 5
-PROTOCOLS = ["xroot", "gsiftp", "srm", "root", "xrootd"]
+PROTOCOLS = ["gsiftp", "xroot", "srm"]
 
 ###################################
 def pythonVersion():


### PR DESCRIPTION
Firstly:
**Removal of protocols that do not work.**
(Suggestion from Adam and Paul):

> Paul and Adam ask that xrootd is removed from the list of protocols (since it will always fail/is not installed), and that only one of root or xroot is tried (since they are the same backend),

Secondly:
Dramatically **increase wait time** upon failed copy to ensure that the repeated copy attempts do not hamper the server with an increased load (also randomise this wait time, to ensure that we avoid distributing a synchronised set of jobs which failed on the same copy command) See issue #44 . 

Waiting ~half a minute for a job that takes 4+ hours shouldn't be a problem. 