### PR TITLE
Copylog

### DIFF
--- a/hejrun.py
+++ b/hejrun.py
@@ -201,7 +201,7 @@ def copy_to_grid(local_file, grid_file, args, maxrange=MAX_COPY_TRIES):
 def remove_file(filepath, args, tries=5, protocol=None):
     if protocol:
         prot = args.gfaldir.split(":")[0]
-        filepath.replace(prot, protocol, 1)
+        filepath = filepath.replace(prot, protocol, 1)
     rmcmd = "{gfal_loc}gfal-rm {f}".format(f=filepath, gfal_loc=args.gfal_location)
 
     file_present = test_file_presence(filepath, args)
@@ -237,7 +237,7 @@ def remove_file(filepath, args, tries=5, protocol=None):
 def test_file_presence(filepath, args, protocol=None):
     if protocol:
         prot = args.gfaldir.split(":")[0]
-        filepath.replace(prot, protocol, 1)
+        filepath = filepath.replace(prot, protocol, 1)
     filename = os.path.basename(filepath)
     lscmd = "{gfal_loc}gfal-ls {file}".format(gfal_loc=args.gfal_location, file=filepath)
     if debug_level > 1:
@@ -261,7 +261,7 @@ def test_file_presence(filepath, args, protocol=None):
 def get_hash(filepath, args, algo="MD5", protocol=None):
     if protocol:
         prot = args.gfaldir.split(":")[0]
-        filepath.replace(prot, protocol, 1)
+        filepath = filepath.replace(prot, protocol, 1)
     hashcmd = "{gfal_loc}gfal-sum {file} {checksum}".format(gfal_loc=args.gfal_location, file=filepath, checksum=algo)
     if debug_level > 1:
         print_flush(hashcmd)

--- a/hejrun.py
+++ b/hejrun.py
@@ -22,9 +22,9 @@ def print_flush(string):
     print(string)
     sys.stdout.flush()
 
-def print_file(string):
-    f = open(LOG_FILE, "a")
-    f.write(string+"\n")
+def print_file(string, logfile=LOG_FILE):
+    with open(logfile, "a") as f:
+        f.write(string+"\n")
 
 # This function must always be the same as the one in program.py
 def warmup_name(runcard, rname):

--- a/hejrun.py
+++ b/hejrun.py
@@ -16,15 +16,18 @@ MAX_COPY_TRIES = 15
 PROTOCOLS = ["xroot", "gsiftp", "srm"]
 LHE_FILE="SherpaLHE_fixed.lhe"
 LOG_FILE="output.log"
+COPY_LOG = "copies.log"
 
 #### Override print with custom version that always flushes to stdout so we have up-to-date logs
 def print_flush(string):
     print(string)
     sys.stdout.flush()
 
+
 def print_file(string, logfile=LOG_FILE):
     with open(logfile, "a") as f:
         f.write(string+"\n")
+
 
 # This function must always be the same as the one in program.py
 def warmup_name(runcard, rname):
@@ -68,6 +71,7 @@ def parse_arguments():
     parser.add_option("-t", "--threads", help = "Number of thread for OMP", default = "1")
     parser.add_option("-e", "--executable", help = "Executable to be run", default = "HEJ")
     parser.add_option("-d", "--debug", help = "Debug level", default="0")
+    parser.add_option("--copy_log", help = "Write copy log file.", action="store_true", default=False)
     parser.add_option("-s", "--seed", help = "Run seed", default="1")
     parser.add_option("-E", "--events", help = "Number of events", default="-1")
 
@@ -217,6 +221,9 @@ def remove_file(filepath, args, tries=5, protocol=None):
 
     # don't crash if gfal-rm throws an error
     except subprocess.CalledProcessError as e:
+        if args.copy_log:
+            print_file("Gfal-rm failed at {t}.".format(t=datetime.datetime.now()), logfile=COPY_LOG)
+            print_file("   > Command issued: {cmd}".format(cmd=rmcmd), logfile=COPY_LOG)
         if debug_level > 1:
             if hasattr(e, 'message'):
                 print_flush(e.message)
@@ -239,6 +246,9 @@ def test_file_presence(filepath, args, protocol=None):
         # In principle, empty if file doesn't exist, so unnecessary to check contents.  Test to be robust against unexpected output.
         filelist = subprocess.check_output(lscmd, shell=True, universal_newlines=True).splitlines()[0]
     except subprocess.CalledProcessError as e:
+        if args.copy_log:
+            print_file("Gfal-ls failed at {t}.".format(t=datetime.datetime.now()), logfile=COPY_LOG)
+            print_file("   > Command issued: {cmd}".format(cmd=lscmd), logfile=COPY_LOG)
         if debug_level > 1:
             if hasattr(e, 'message'):
                 print_flush(e.message)
@@ -258,6 +268,9 @@ def get_hash(filepath, args, algo="MD5", protocol=None):
     try:
         hash = subprocess.check_output(hashcmd, shell=True, universal_newlines=True).split()[1]
     except subprocess.CalledProcessError as e:
+        if args.copy_log:
+            print_file("Gfal-sum failed at {t}.".format(t=datetime.datetime.now()), logfile=COPY_LOG)
+            print_file("   > Command issued: {cmd}".format(cmd=hashcmd), logfile=COPY_LOG)
         if debug_level > 1:
             if hasattr(e, 'message'):
                 print_flush(e.message)
@@ -296,7 +309,6 @@ def grid_copy(infile, outfile, args, maxrange=MAX_COPY_TRIES):
                 return retval
             elif retval == 0 and not file_present:
                 print_flush("Copy command succeeded, but failed to copy file. Retrying.")
-                retval += 1
             elif retval != 0 and file_present:
                 outfile_hash = get_hash(outfile, args, protocol="gsiftp")
                 if infile_hash == outfile_hash:
@@ -306,7 +318,12 @@ def grid_copy(infile, outfile, args, maxrange=MAX_COPY_TRIES):
                     print_flush("Copy command reported errors and the transferred file was corrupted. Retrying.")
             else:
                 print_flush("Copy command failed. Retrying.")
-            # sleep time scales steeply with failed attempts (min wait 1s, max wait ~10 mins)
+            if args.copy_log:
+                print_file("Copy failed at {t}.".format(t=datetime.datetime.now()), logfile=COPY_LOG)
+                print_file("   > Command issued: {cmd}".format(cmd=cmd), logfile=COPY_LOG)
+                print_file("   > Returned error code: {ec}".format(ec=retval), logfile=COPY_LOG)
+                print_file("   > File now present: {fp}".format(fp=file_present), logfile=COPY_LOG)
+            # sleep time scales steeply with failed attempts (min wait 1s, max wait ~2 mins)
             sleep((i+1)*(j+1)**2)
 
     # Copy failed to complete successfully; attemt to clean up corrupted files if present.
@@ -371,6 +388,8 @@ def print_node_info(outputfile):
     os.system("hostname >> {0}".format(outputfile))
     os.system("gcc --version >> {0}".format(outputfile))
     os.system("python --version >> {0}".format(outputfile))
+    os.system("python3 --version >> {0}".format(outputfile))
+    os.system("gfal-copy --version >> {0}".format(outputfile))
     os.system("cat {0}".format(outputfile)) ## print to log
 
 def end_program(status, debug_level):
@@ -438,6 +457,7 @@ if __name__ == "__main__":
 
     args = parse_arguments()
     debug_level = int(args.debug)
+    copy_log = args.copy_log
 
     lhapdf_local = ""
     if args.use_cvmfs_lhapdf:
@@ -448,6 +468,10 @@ if __name__ == "__main__":
         # Architecture info
         print_flush("Python version: {0}".format(sys.version))
         print_node_info("node_info.log")
+
+    if copy_log:
+        # initialise with node name
+        os.system("hostname >> {0}".format(COPY_LOG))
 
     # Debug info
     if debug_level > 16:

--- a/nnlorun.py
+++ b/nnlorun.py
@@ -361,7 +361,7 @@ def copy_to_grid(local_file, grid_file, args, maxrange=MAX_COPY_TRIES):
 def remove_file(filepath, args, tries=5, protocol=None):
     if protocol:
         prot = args.gfaldir.split(":")[0]
-        filepath.replace(prot, protocol, 1)
+        filepath = filepath.replace(prot, protocol, 1)
     rmcmd = "{gfal_loc}gfal-rm {f}".format(f=filepath, gfal_loc=args.gfal_location)
 
     file_present = test_file_presence(filepath, args)
@@ -397,7 +397,7 @@ def remove_file(filepath, args, tries=5, protocol=None):
 def test_file_presence(filepath, args, protocol=None):
     if protocol:
         prot = args.gfaldir.split(":")[0]
-        filepath.replace(prot, protocol, 1)
+        filepath = filepath.replace(prot, protocol, 1)
     filename = os.path.basename(filepath)
     lscmd = "{gfal_loc}gfal-ls {file}".format(gfal_loc=args.gfal_location, file=filepath)
     if debug_level > 1:
@@ -421,7 +421,7 @@ def test_file_presence(filepath, args, protocol=None):
 def get_hash(filepath, args, algo="MD5", protocol=None):
     if protocol:
         prot = args.gfaldir.split(":")[0]
-        filepath.replace(prot, protocol, 1)
+        filepath = filepath.replace(prot, protocol, 1)
     hashcmd = "{gfal_loc}gfal-sum {file} {checksum}".format(gfal_loc=args.gfal_location, file=filepath, checksum=algo)
     if debug_level > 1:
         print_flush(hashcmd)

--- a/sherparun.py
+++ b/sherparun.py
@@ -192,7 +192,7 @@ def copy_to_grid(local_file, grid_file, args, maxrange=MAX_COPY_TRIES):
 def remove_file(filepath, args, tries=5, protocol=None):
     if protocol:
         prot = args.gfaldir.split(":")[0]
-        filepath.replace(prot, protocol, 1)
+        filepath = filepath.replace(prot, protocol, 1)
     rmcmd = "{gfal_loc}gfal-rm {f}".format(f=filepath, gfal_loc=args.gfal_location)
 
     file_present = test_file_presence(filepath, args)
@@ -228,7 +228,7 @@ def remove_file(filepath, args, tries=5, protocol=None):
 def test_file_presence(filepath, args, protocol=None):
     if protocol:
         prot = args.gfaldir.split(":")[0]
-        filepath.replace(prot, protocol, 1)
+        filepath = filepath.replace(prot, protocol, 1)
     filename = os.path.basename(filepath)
     lscmd = "{gfal_loc}gfal-ls {file}".format(gfal_loc=args.gfal_location, file=filepath)
     if debug_level > 1:
@@ -252,7 +252,7 @@ def test_file_presence(filepath, args, protocol=None):
 def get_hash(filepath, args, algo="MD5", protocol=None):
     if protocol:
         prot = args.gfaldir.split(":")[0]
-        filepath.replace(prot, protocol, 1)
+        filepath = filepath.replace(prot, protocol, 1)
     hashcmd = "{gfal_loc}gfal-sum {file} {checksum}".format(gfal_loc=args.gfal_location, file=filepath, checksum=algo)
     if debug_level > 1:
         print_flush(hashcmd)

--- a/src/HEJ/hej_header.py
+++ b/src/HEJ/hej_header.py
@@ -31,6 +31,7 @@ baseSeed   = 1
 events     = 123
 jobName    = "HEJ"
 debug_level = 16
+copy_log   = False
 stacksize = 5000 # MB RAM per job smaller->higher priority (slurm only)
 runmode = "HEJ"
 

--- a/src/pyHepGrid/headers/template_header.py
+++ b/src/pyHepGrid/headers/template_header.py
@@ -20,6 +20,7 @@ baseSeed   = 100
 events     = 100
 jobName    = "testjob"
 debug_level = 0
+copy_log   = False
 stacksize = 50 #MB
 
 # Grid folder config

--- a/src/pyHepGrid/src/Backend.py
+++ b/src/pyHepGrid/src/Backend.py
@@ -614,6 +614,8 @@ class Backend(_mode):
             dictionary.update({
                 "use_custom_rivet":header.use_custom_rivet,
                 "rivet_folder":header.grid_rivet_dir})
+        if header.copy_log:
+            dictionary["copy_log"] = header.copy_log
         return dictionary
 
     def _make_base_argstring(self, runcard, runtag):


### PR DESCRIPTION
First attempt at creating a new (optional) log to keep track of gfal command success rates.

The information should be useful both for developers (so we can optimise our scripts to maximise copy success rates without risking malign server effects as in #44) and to the ARC admins (to help diagnose the causes of copy failures).

It can be enabled for individual runs with `copy_log = True` in the runcard, and in general with `copy_log = True` in your header.

@marianheil , could you test it for HEJ?