### PR TITLE
`print_flush()` not defined nor needed. Remove.

### DIFF
--- a/src/pyHepGrid/src/utilities.py
+++ b/src/pyHepGrid/src/utilities.py
@@ -331,7 +331,6 @@ def gfal_copy(infile, outfile, maxrange=MAX_COPY_TRIES):
     header.logger.info("Copying {0} to {1}".format(infile, outfile))
     protoc = header.gfaldir.split(":")[0]
     for i in range(maxrange):
-        print_flush("Attempting copy try {0}".format(i+1))
         for protocol in PROTOCOLS: # cycle through available protocols until one works.
             infile_tmp = infile.replace(protoc, protocol)
             outfile_tmp = outfile.replace(protoc, protocol)


### PR DESCRIPTION
`print_flush()` not defined in utilities.py. Breaks initialisation copying. Simple fix.
Closes #52 