### PR TITLE
add a include_arguments method to the program interface

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -45,7 +45,7 @@ grid outside of Durham(!)**
 
 ## 3. GFAL SETUP
 
-### Note. LFN is now unsupported!
+### Note: LFN is now unsupported! It got replaced by `gfal`.
 
 put this into your bashrc:
 ```bash
@@ -109,7 +109,7 @@ To start using `pyHepGrid` you need to do the following steps.
     setting you have in your personal header, e.g. `BaseSeed` or `producRun`.
 4. Create folders on gfal to save your in and output. They have to match
     `grid_input_dir`, `grid_output_dir` and `grid_warmup_dir` of your header
-5. For non NNNLOJet developers: Write you own `runfile` similar to `nnlorun.py`.
+5. If you use you own program: Write you own `runfile` similar to `nnlorun.py`.
     This script will be ran on each node, so it should be *self-contained* and
     *Python 2.4 compatible*. It should also be able to handle all arguments of
     the `nnnnlorun.py`, even if they are not used in the script itself. It is
@@ -123,19 +123,21 @@ To start using `pyHepGrid` you need to do the following steps.
 python3 setup.py install --user
 python3 setup.py develop --user
 ```
-(Include the `--prefix` option and add to a location contained in `$PYTHONPATH` 
-if you want to install it elsewhere). `--user` is used on the gridui as we don't 
+(Include the `--prefix` option and add to a location contained in `$PYTHONPATH`
+if you want to install it elsewhere). `--user` is used on the gridui as we don't
 have access to the python3 installation - if you have your own install, feel free
-to drop it. 
-We currently need to be in develop mode given the way that the header system works - 
+to drop it.
+We currently need to be in develop mode given the way that the header system works -
 the plan is for this to change at some point.
 
-Alternatively: if you wish to run pyHepGrid from within a Conda environment, install the scripts by moving to the directory containing setup.py and running:
+Alternatively: if you wish to run pyHepGrid from within a Conda environment,
+install the scripts by moving to the directory containing setup.py and running:
 ```bash
 conda install conda-build
 conda develop .
 ```
-If prompted to install any dependencies required by conda-build in step (1), type 'Y' to proceed.
+If prompted to install any dependencies required by conda-build in step (1),
+type 'Y' to proceed.
 
 
 After this you should be able to run `pyHepGrid test runcards/your_runcard.py
@@ -145,6 +147,38 @@ without sourcing your `~/.bashrc`. If this works fine you can try submitting to
 the arc  test queue with `pyHepGrid run runcards/your_runcard.py -B --test`. The
 test queue highly limited in resources. **Only submit a few short jobs to it**
 (<10).
+
+### 4.1. Further customisations (advanced usage)
+
+Beside the header and runcard setup, `pyHepGrid` has two big *attack points* for
+customisations. First and foremost the `runfile` which is run on each grid node.
+This is similar to other grid-scripts that you might have used before. However
+you can also change some local background behaviour through `runmodes`. A
+`runmode` is *program* specific, e.g. there is a `runmode` `"NNLOJET"` and
+`"HEJ"`. The behaviour of `pyHepGrid ini` is completely controlled by a
+`runmode`. You could set it up to upload some common files (runcards,
+warmup-files, dependencies, etc.) with `gfal` before submitting jobs.
+
+If you want to implement your own `runmode` write a *program* class as a
+subclass of the [`ProgramInterface`](../src/pyHepGrid/src/program_interface.py)
+and register it in the [`mode_selector`](../src/pyHepGrid/src/runmodes.py). As
+always, to get started it is easiest to look at existing `runmodes`/programs in
+[`programs.py`](../src/pyHepGrid/src/programs.py). Dependent on your setup you
+might not need to implement all functions. For example to use the initialisation
+in production mode you only need to implement the `init_production` function.
+
+You can also use your custom program class to pass non-standard arguments to
+your `runfile` by overwriting the `include_arguments`,
+`include_production_arguments` or `include_warmup_arguments`functions. You can
+add, change or even delete entries as you want (the latter is not advised). The
+output of `include_agruments` is directly passed to your `runfile` as a
+command-line argument of the form `--key value` for Arc and Dirac, or replaces
+the corresponding arguments in the `slurm_template`.
+
+> `pyHepGrid` will and can not sanitise your setup and it is your responsibility
+to ensure your code runs as intended. As a general advice try to reuse code
+shipped with `pyHepGrid` where possible, since this should be tested to some
+expend.
 
 ## 5. PROXY SETUP
 

--- a/src/pyHepGrid/src/Backend.py
+++ b/src/pyHepGrid/src/Backend.py
@@ -630,7 +630,9 @@ class Backend(_mode):
         base_string = self._make_base_argstring(runcard, runtag)
         production_dict = {'Production': None,
                         'seed': seed }
-
+        # Pass the current production arguments to the program interface
+        # and let it add new arguments
+        production_dict = super().include_production_arguments(production_dict)
         production_str = self._format_args(production_dict)
         return base_string + production_str
 
@@ -645,6 +647,10 @@ class Backend(_mode):
             warmup_dict['port'] = port
             warmup_dict['Host'] = header.server_host
             warmup_dict['Sockets'] = None
+
+        # Pass the current warmup arguments to the program interface
+        # and let it add new arguments
+        warmup_dict = super().include_warmup_arguments(warmup_dict)
 
         warmup_str = self._format_args(warmup_dict)
         return base_string + warmup_str

--- a/src/pyHepGrid/src/program_interface.py
+++ b/src/pyHepGrid/src/program_interface.py
@@ -17,6 +17,12 @@ class ProgramInterface(object):
     # Add the possibility of massaging a list of arguments
     def include_arguments(self, argument_dict):
         return argument_dict
+    # Add production arguments (by default, defer to generic include_arguments)
+    def include_production_arguments(self, argument_dict):
+        return self.include_arguments(argument_dict)
+    # Add warmup arguments (by default, defer to generic include_arguments)
+    def include_warmup_arguments(self, argument_dict):
+        return self.include_arguments(argument_dict)
 
     # Checks for the grid storage system
     def get_grid_from_stdout(self, jobid, jobinfo):


### PR DESCRIPTION
It basically adds three methods to the program interface:

```
include_arguments
include_production_arguments
include_warmup_arguments
```
They all take a dictionary and return a dictionary. By default the second and the third defer to the first one (i.e., the same arguments are added in production and warmup).

There are other possibilities though but I think this one is the one that gave more granularity in order to choose different things for warmup and production.