### PR TITLE
Allow loading custom runmode without modifying `pyHepGrid` Code

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -160,9 +160,11 @@ you can also change some local background behaviour through `runmodes`. A
 warmup-files, dependencies, etc.) with `gfal` before submitting jobs.
 
 If you want to implement your own `runmode` write a *program* class as a
-subclass of the [`ProgramInterface`](../src/pyHepGrid/src/program_interface.py)
-and register it in the [`mode_selector`](../src/pyHepGrid/src/runmodes.py). As
-always, to get started it is easiest to look at existing `runmodes`/programs in
+subclass of the [`ProgramInterface`](../src/pyHepGrid/src/program_interface.py).
+You can then load your program as a `runmode` in your `runcard.py`, e.g. you
+could specify `runmode="pyHepGrid.src.programs.HEJ"` to explicitly load HEJ (the
+shorter `runmode=HEJ` is just an alias). As always, to get started it is easiest
+to look at existing `runmodes`/programs in
 [`programs.py`](../src/pyHepGrid/src/programs.py). Dependent on your setup you
 might not need to implement all functions. For example to use the initialisation
 in production mode you only need to implement the `init_production` function.

--- a/src/pyHepGrid/headers/template_header.py
+++ b/src/pyHepGrid/headers/template_header.py
@@ -11,9 +11,9 @@ def get_cmd_output(*args,**kwargs):
 # Global Variables
 # Global Variables (default values, can be changed by runcard.py)
 runcardDir = "/path/to/runcard/directory/" # Directory for grid runcard storage
-executable_src_dir = "/path/to/nnlojet/directory"             # Directory for NNLOJET
-executable_exe = "NNLOJET"                               # Executable name
-runmode    = "NNLOJET"
+executable_src_dir = "/path/to/nnlojet/directory"       # Directory for NNLOJET
+executable_exe = "NNLOJET"                              # Executable name
+runmode    = "NNLOJET"                                  # Program mode
 warmupthr  = 8
 producRun  = 100
 baseSeed   = 100

--- a/src/pyHepGrid/src/Backend.py
+++ b/src/pyHepGrid/src/Backend.py
@@ -1,6 +1,7 @@
 from collections import Counter
 import datetime
 import os
+import importlib
 import pyHepGrid.src.dbapi
 from pyHepGrid.src.header import logger
 import pyHepGrid.src.utilities as util
@@ -10,7 +11,13 @@ import multiprocessing as mp
 import sys
 
 counter = None
-_mode = pyHepGrid.src.runmodes.mode_selector[header.runmode.upper()]
+
+if header.runmode.upper() in pyHepGrid.src.runmodes.mode_selector:
+    _mode = pyHepGrid.src.runmodes.mode_selector[header.runmode.upper()]
+else:
+    package, module = header.runmode.rsplit('.', 1)
+    _mode = getattr(importlib.import_module(package), module)
+    logger.info(f"Overriding run mode to {_mode}")
 
 
 def init_counter(args):


### PR DESCRIPTION
This should allow adding a new `program` without modifying `mode_selector`. The previous "standard" options are not affected.