### PR TITLE
Removed SherpaLHEF

### DIFF
--- a/hejrun.py
+++ b/hejrun.py
@@ -15,7 +15,7 @@ except KeyError as e:
 MAX_COPY_TRIES = 15
 GFAL_TIMEOUT = 300
 PROTOCOLS = ["xroot", "gsiftp", "srm"]
-LHE_FILE="SherpaLHE_fixed.lhe"
+LHE_FILE="SherpaLHE.lhe"
 LOG_FILE="output.log"
 COPY_LOG = "copies.log"
 
@@ -444,7 +444,6 @@ def run_sherpa(args):
     if int(args.events) > 0:
         command += " -e {0} ".format(args.events)
     status = run_command(command)
-    status += run_command("SherpaLHEF SherpaLHE.lhe {0}".format(LHE_FILE))
     # TODO run:
     #   unweighter (maybe)
     return status


### PR DESCRIPTION
Removed SherpaLHEF since it is not needed any more for the newest HEJ version

The change is minimal and only affects HEJ, however this breaks support for older HEJ versions (prior to 5c09b80f0bfb7c1c4086b8da3cf16929ff87b8e2). We could also start using gzipped LHE files.
